### PR TITLE
refactor: simplify subagent run result

### DIFF
--- a/home/.pi/agent/extensions/subagents/index.ts
+++ b/home/.pi/agent/extensions/subagents/index.ts
@@ -7,7 +7,7 @@
  * the process tree via PI_SUBAGENT_DEPTH).
  *
  * Architecture: this is the only module that crosses into pi's tool world.
- * It composes Results from agents.ts / process.ts and converts Err → throw
+ * It composes agent/process helpers and converts failed child runs into throws
  * at the boundary (pi's runtime marks `isError: true` only on thrown errors;
  * a returned `isError` field is silently dropped — see agent-loop.js).
  */
@@ -114,14 +114,12 @@ export default function (_pi: ExtensionAPI) {
 					: undefined,
 			});
 
-			// ── resolve (Err → throw, so pi marks isError) ──
-			const details = result.match(
-				(d) => d,
-				(e) => {
-					throw new Error(spawnErrorMessage(e));
-				},
-			);
+			// ── resolve (failed child run → throw, so pi marks isError) ──
+			if (!result.ok) {
+				throw new Error(spawnErrorMessage(result.error));
+			}
 
+			const details = result.details;
 			const finalText = getFinalText(details.messages);
 			return { content: [{ type: "text" as const, text: finalText || "(no output)" }], details };
 		},

--- a/home/.pi/agent/extensions/subagents/process.ts
+++ b/home/.pi/agent/extensions/subagents/process.ts
@@ -4,8 +4,8 @@
  * Runs the spawned agent as an isolated `pi --mode json --print --no-session`
  * subprocess — same pattern as pi's built-in bash tool. Streams JSON events
  * off stdout, aggregates usage/tool/text state, and emits throttled UI
- * updates. ResultAsync wraps the spawn so the tool layer's only job is to
- * resolve the agent and render the outcome.
+ * updates. The run returns a small discriminated result so the tool boundary
+ * can turn failed child runs into thrown pi tool errors.
  */
 
 import * as fs from "node:fs";
@@ -13,7 +13,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { execa } from "execa";
 import type { Message } from "@earendil-works/pi-ai";
-import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import type { AgentConfig } from "./agents.ts";
 import { z } from "zod";
 
@@ -47,9 +46,6 @@ const EventSchema = z.object({
   type: z.literal("message_end"),
   message: MessageSchema,
 });
-
-
-
 
 export interface RunUsage {
   input: number;
@@ -89,6 +85,10 @@ export type SpawnError =
   | { kind: "exit"; details: RunDetails }
   | { kind: "aborted"; details: RunDetails };
 
+export type RunResult =
+  | { ok: true; details: RunDetails }
+  | { ok: false; error: SpawnError };
+
 export interface RunParams {
   defaultCwd: string;
   agent: AgentConfig;
@@ -109,16 +109,13 @@ export interface BuildPiArgsParams {
   message: string;
 }
 
-/** Spawns the child and resolves Ok on a clean (exit 0) run, Err otherwise. */
-export function runSubprocess(params: RunParams): ResultAsync<RunDetails, SpawnError> {
+/** Spawns the child and resolves ok=true on a clean (exit 0) run, ok=false otherwise. */
+export async function runSubprocess(params: RunParams): Promise<RunResult> {
   const details = initDetails(params);
-  // runAndCollect never rejects — failures land in details.aborted/exitCode —
-  // so fromSafePromise is the honest wrapper (no synthetic error type).
-  return ResultAsync.fromSafePromise(runAndCollect(params, details)).andThen((d) => {
-    if (d.aborted) return errAsync({ kind: "aborted" as const, details: d });
-    if (d.exitCode !== 0) return errAsync({ kind: "exit" as const, details: d });
-    return okAsync(d);
-  });
+  const finished = await runAndCollect(params, details);
+  if (finished.aborted) return { ok: false, error: { kind: "aborted", details: finished } };
+  if (finished.exitCode !== 0) return { ok: false, error: { kind: "exit", details: finished } };
+  return { ok: true, details: finished };
 }
 
 function initDetails(params: RunParams): RunDetails {
@@ -190,8 +187,7 @@ async function runAndCollect(params: RunParams, details: RunDetails): Promise<Ru
     details.stderr = typeof stderr === "string" ? stderr : "";
     if (params.signal?.aborted) details.aborted = true;
   } catch (error) {
-    // runAndCollect must never reject — runSubprocess wraps it in
-    // ResultAsync.fromSafePromise. Fold any execa/iterator error into
+    // runAndCollect must never reject. Fold any execa/iterator error into
     // details so the tool layer still renders something.
     details.exitCode = 1;
     details.stderr = String(error instanceof Error ? error.message : error);


### PR DESCRIPTION
### Simplification

Replace the subagent subprocess helper's `neverthrow.ResultAsync` return path with a small local discriminated result type: `{ ok: true, details } | { ok: false, error }`.

### Why the current design is overcomplicated

`runSubprocess` is an async subprocess boundary that already folds child-process failures into `RunDetails`. The only caller immediately awaited the `ResultAsync` and used `.match(...)` to either get details or throw a tool-boundary error. That made the process layer depend on `ResultAsync`, `okAsync`, and `errAsync` for a single producer/single consumer path without adding retry, composition, or recovery value.

### Behavioral contract

The following behavior must remain unchanged:

- `spawn_agent` still runs the child as `pi --mode json --print --no-session`.
- `PI_SUBAGENT_DEPTH` is still incremented for the child process.
- Aborted runs still become `spawn_agent aborted.` errors.
- Non-zero child exits still throw `Subagent exited with code <n>.` plus stderr/final text when available.
- Successful runs still return the child's final assistant text, or `(no output)` when empty.
- Partial UI updates, final render details, usage accounting, tool-call accounting, stderr capture, temp prompt cleanup, cwd handling, model/tool/thinking arguments, and context-window display behavior are preserved.
- No public tool schema, agent frontmatter contract, pi CLI invocation, persisted data, configuration contract, logging, or metric shape changes.

### Before and after

Before:

- `process.ts` imported `ResultAsync`, `okAsync`, and `errAsync`.
- `runSubprocess` wrapped `runAndCollect(...)` with `ResultAsync.fromSafePromise(...)` and converted collected details into `Ok`/`Err`.
- `index.ts` awaited the result and used `.match(...)` to throw at the pi tool boundary.

After:

- `process.ts` exports a local `RunResult` union.
- `runSubprocess` awaits `runAndCollect(...)` directly and returns the same success/error distinction without the extra `ResultAsync` abstraction.
- `index.ts` checks `if (!result.ok)` and throws the same `spawnErrorMessage(...)`; success still reads `result.details`.

Specific evidence:

- Removed the `neverthrow` import from `home/.pi/agent/extensions/subagents/process.ts`.
- Removed the `ResultAsync.fromSafePromise(...).andThen(...)` call chain from the subprocess flow.
- Kept the existing `SpawnError` shape and `spawnErrorMessage(...)` handling intact.
- Reduced one internal ownership boundary between subprocess collection and tool-boundary error conversion.

### Validation

Commands intended for validation:

- `cd home/.pi/agent/extensions && npm run check`

I could not execute the command in this automation environment because the repository workspace was not available for local command execution. The change was therefore limited to a small TypeScript control-flow simplification that preserves the existing exported helper contracts and test-covered behavior around argument building, event ingestion, final text extraction, and argument previews.

### Risk assessment

Behavior-sensitive areas examined:

- The `spawn_agent` tool boundary still throws only after failed child runs, preserving pi's `isError` behavior.
- `runAndCollect` still catches subprocess/iterator errors and stores them in `RunDetails`; the simplification does not let those errors reject past the process layer.
- Aborted and non-zero-exit cases still carry the same `SpawnError` details consumed by `spawnErrorMessage(...)`.
- The subprocess invocation, update throttling, prompt temp-file handling, and JSON event ingestion code paths were intentionally left unchanged.

Risk is low because this removes only the internal result wrapper around an already-collected run result and leaves the subprocess behavior itself unchanged.

### Scope

Not simplified:

- `agents.ts` still uses `neverthrow.Result` for discovery/resolve errors because that module has multiple validation-style call sites and this PR is intentionally limited to the subprocess run-result path.
- `zod` validation of the child JSON event stream was left intact because it guards an external process output boundary.
- Rendering, throttling, process invocation, and agent discovery were left untouched to keep the review narrow.