### PR TITLE
bug: prevent wific from truncating SSIDs with spaces

### DIFF
--- a/.local/bin/wific
+++ b/.local/bin/wific
@@ -6,9 +6,23 @@ set -euo pipefail
 command -v iwctl >/dev/null 2>&1 || { echo "wific: iwctl not found" >&2; exit 1; }
 command -v fzf >/dev/null 2>&1 || { echo "wific: fzf not found" >&2; exit 1; }
 
+strip_ansi() {
+  sed 's/\x1b\[[0-9;]*m//g'
+}
+
+parse_iwctl_networks() {
+  awk '
+    NR > 4 {
+      sub(/^[[:space:]]*>?[[:space:]]*/, "")
+      sub(/[[:space:]]+(open|psk|8021x|owe|wep)[[:space:]]+\**$/, "")
+      if (length) print
+    }
+  '
+}
+
 device="$(
   iwctl device list |
-    sed 's/\x1b\[[0-9;]*m//g' |
+    strip_ansi |
     awk 'NR > 4 {print $1}' |
     grep . |
     fzf --prompt='device > ' --no-multi
@@ -20,8 +34,8 @@ iwctl station "$device" scan >/dev/null
 
 network="$(
   iwctl station "$device" get-networks |
-    sed 's/\x1b\[[0-9;]*m//g' |
-    awk 'NR > 4 {sub(/^> /, ""); print $1}' |
+    strip_ansi |
+    parse_iwctl_networks |
     grep . |
     fzf --prompt='network > ' --no-multi
 )" || exit 0

--- a/tests/wific-ssid-spaces.test.sh
+++ b/tests/wific-ssid-spaces.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+log="$tmp_dir/iwctl.log"
+export WIFIC_TEST_LOG="$log"
+
+cat >"$tmp_dir/iwctl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$WIFIC_TEST_LOG"
+
+case "$*" in
+  "device list")
+    cat <<'OUT'
+                               Devices
+--------------------------------------------------------------------------------
+  Name                Address             Powered   Adapter   Mode
+--------------------------------------------------------------------------------
+  wlan0               00:11:22:33:44:55   on        phy0      station
+OUT
+    ;;
+  "station wlan0 scan")
+    ;;
+  "station wlan0 get-networks")
+    cat <<'OUT'
+                               Available networks
+--------------------------------------------------------------------------------
+  Network name                         Security            Signal
+--------------------------------------------------------------------------------
+  Office                               psk                 ****
+  Cafe WiFi 5G                         psk                 ****
+OUT
+    ;;
+  station\ wlan0\ connect*)
+    printf 'connect_arg_count=%s\n' "$#" >>"$WIFIC_TEST_LOG"
+    printf 'connect_arg_4=%s\n' "$4" >>"$WIFIC_TEST_LOG"
+    ;;
+  *)
+    echo "unexpected iwctl call: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$tmp_dir/iwctl"
+
+cat >"$tmp_dir/fzf" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+prompt=""
+while (($#)); do
+  case "$1" in
+    --prompt=*) prompt="${1#--prompt=}" ;;
+    --prompt) shift; prompt="${1:-}" ;;
+  esac
+  shift || true
+done
+
+if [[ "$prompt" == "device > " ]]; then
+  cat >/dev/null
+  printf 'wlan0\n'
+else
+  grep -Fx 'Cafe WiFi 5G'
+fi
+STUB
+chmod +x "$tmp_dir/fzf"
+
+PATH="$tmp_dir:$PATH" "$repo_dir/.local/bin/wific" >/dev/null
+
+grep -Fx 'station wlan0 connect Cafe WiFi 5G' "$log" >/dev/null
+grep -Fx 'connect_arg_count=4' "$log" >/dev/null
+grep -Fx 'connect_arg_4=Cafe WiFi 5G' "$log" >/dev/null


### PR DESCRIPTION
### Bug

`.local/bin/wific` parsed the selected `iwctl station <device> get-networks` row with `awk '{print $1}'`, so any Wi-Fi SSID containing spaces was truncated before being passed to `iwctl station <device> connect`.

### Severity and impact

This breaks a normal user flow for common home, cafe, and office Wi-Fi names such as `Cafe WiFi 5G`. The script cannot connect to those networks because it passes only the first word of the SSID to `iwctl`.

### Evidence

Relevant files and functions:

* `.local/bin/wific`: network selection pipeline previously used `awk 'NR > 4 {sub(/^> /, ""); print $1}'` after `iwctl station "$device" get-networks`.
* `tests/wific-ssid-spaces.test.sh`: added a deterministic stubbed `iwctl`/`fzf` regression test.

Observed incorrect behavior:

Given an `iwctl get-networks` row like:

```text
  Cafe WiFi 5G                         psk                 ****
```

The old parser emitted `Cafe`, not `Cafe WiFi 5G`. That meant the final command became equivalent to:

```bash
iwctl station wlan0 connect Cafe
```

instead of passing the full SSID as one argument.

This is a real defect because SSIDs with spaces are valid and common, and the script's purpose is to select and connect to the chosen network from the `iwctl` network list.

### Reproduce

Setup:

```bash
git checkout master
bash tests/wific-ssid-spaces.test.sh
```

Input or triggering conditions:

The test stubs `iwctl` so `station wlan0 get-networks` returns a network named `Cafe WiFi 5G`, and stubs `fzf` to select that network.

Exact command:

```bash
bash tests/wific-ssid-spaces.test.sh
```

Actual result before the fix:

The old parser emits only `Cafe`, so the stubbed `fzf` cannot select the exact `Cafe WiFi 5G` line and the test fails because no correct connect call is recorded.

Expected result:

The script preserves the SSID text and calls `iwctl station wlan0 connect` with `Cafe WiFi 5G` as a single fourth argument.

### Root cause

The parser treated the `iwctl get-networks` output as whitespace-delimited fields and printed only `$1`. That is safe for device names, but not for SSIDs because SSIDs may contain spaces.

### Fix

Split the reusable ANSI stripping into `strip_ansi`, add `parse_iwctl_networks`, and parse network rows by removing the leading active marker and trailing `Security`/`Signal` columns while keeping the network name intact. The final `iwctl station "$device" connect "$network"` call remains quoted.

### Validation

Commands run:

* `compare master...bug/wific-ssid-spaces` via GitHub compare API — result: branch is 2 commits ahead, 0 behind; only `.local/bin/wific` and `tests/wific-ssid-spaces.test.sh` changed.

Regression test added:

* `tests/wific-ssid-spaces.test.sh` stubs `iwctl` and `fzf`, selects `Cafe WiFi 5G`, and asserts the connect command receives the full SSID as one argument.

I could not run the shell test locally inside this connector runtime; the PR includes the exact command for a reviewer to run.

### Scope

Intentionally not changed:

* device parsing,
* the `iwctl`/`fzf` user flow,
* Linux-only checks,
* unrelated dotfiles or pi-web code.