### PR TITLE
refactor: simplify agent discovery result handling

### DIFF
--- a/home/.pi/agent/extensions/subagents/agents.ts
+++ b/home/.pi/agent/extensions/subagents/agents.ts
@@ -17,7 +17,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
-import { err, ok, type Result } from "neverthrow";
 import { z } from "zod";
 
 export interface AgentConfig {
@@ -43,6 +42,10 @@ export type DiscoverError =
 	| { kind: "read_dir"; dir: string; cause: NodeJS.ErrnoException }
 	| { kind: "empty"; dir: string };
 
+export type DiscoverResult =
+	| { agents: AgentConfig[] }
+	| { error: DiscoverError };
+
 const AGENTS_DIR = path.join(getAgentDir(), "extensions", "subagents", "agents");
 
 export function agentsDir(): string {
@@ -51,16 +54,16 @@ export function agentsDir(): string {
 
 /**
  * Read every `*.md` in the agents dir, parse frontmatter, and return the
- * valid ones sorted by name. Returns Err on an unreadable dir (permission,
+ * valid ones sorted by name. Returns an error on an unreadable dir (permission,
  * IO) or when no usable agent was found at all (so the caller can give a
  * useful error instead of a confusing "unknown type" on the first spawn).
  */
-export function discoverAgents(): Result<AgentConfig[], DiscoverError> {
+export function discoverAgents(): DiscoverResult {
 	let entries: fs.Dirent[];
 	try {
 		entries = fs.readdirSync(AGENTS_DIR, { withFileTypes: true });
 	} catch (cause) {
-		return err({ kind: "read_dir", dir: AGENTS_DIR, cause: cause as NodeJS.ErrnoException });
+		return { error: { kind: "read_dir", dir: AGENTS_DIR, cause: cause as NodeJS.ErrnoException } };
 	}
 
 	const agents: AgentConfig[] = [];
@@ -82,10 +85,10 @@ export function discoverAgents(): Result<AgentConfig[], DiscoverError> {
 		if (parsed) agents.push(parsed);
 	}
 
-	if (agents.length === 0) return err({ kind: "empty", dir: AGENTS_DIR });
+	if (agents.length === 0) return { error: { kind: "empty", dir: AGENTS_DIR } };
 
 	agents.sort((a, b) => a.name.localeCompare(b.name));
-	return ok(agents);
+	return { agents };
 }
 
 function parseAgentFile(filePath: string, content: string): AgentConfig | undefined {
@@ -114,11 +117,7 @@ export function formatAgentList(agents: AgentConfig[]): string {
 	return agents.map((a) => `${a.name}: ${a.description}`).join("; ") || "none";
 }
 
-/** Find a role by name. Err carries the full list so callers can render it. */
-export function resolveAgent(
-	agents: AgentConfig[],
-	name: string,
-): Result<AgentConfig, { requested: string; available: AgentConfig[] }> {
-	const found = agents.find((a) => a.name === name);
-	return found ? ok(found) : err({ requested: name, available: agents });
+/** Find a role by name. Undefined means the caller should render the full list. */
+export function resolveAgent(agents: AgentConfig[], name: string): AgentConfig | undefined {
+	return agents.find((a) => a.name === name);
 }

--- a/home/.pi/agent/extensions/subagents/index.ts
+++ b/home/.pi/agent/extensions/subagents/index.ts
@@ -26,12 +26,11 @@ export default function (_pi: ExtensionAPI) {
 	// name+description list, not a hand-written hint that drifts the moment
 	// someone adds a new agents/*.md. A broken agents dir fails loud at load
 	// — a silently registered tool that always errors is worse than no tool.
-	const agents = discoverAgents().match(
-		(list) => list,
-		(e) => {
-			throw new Error(discoveryErrorMessage(e));
-		},
-	);
+	const discovery = discoverAgents();
+	if ("error" in discovery) {
+		throw new Error(discoveryErrorMessage(discovery.error));
+	}
+	const agents = discovery.agents;
 	const agentList = agents
 		.map((a) => `- **${a.name}** — ${a.description}`)
 		.join("\n");
@@ -84,12 +83,10 @@ export default function (_pi: ExtensionAPI) {
 			}
 
 			const requestedType = params.agent_type?.trim() || "default";
-			const agent = resolveAgent(agents, requestedType).match(
-				(a) => a,
-				(e) => {
-					throw new Error(`Unknown agent_type '${e.requested}'. Available: ${formatAgentList(e.available)}.`);
-				},
-			);
+			const agent = resolveAgent(agents, requestedType);
+			if (!agent) {
+				throw new Error(`Unknown agent_type '${requestedType}'. Available: ${formatAgentList(agents)}.`);
+			}
 
 			const [provider, modelId] = (agent.model ?? "").split("/");
 			const contextWindow = provider && modelId


### PR DESCRIPTION
### Simplification

Removes the `neverthrow` `Result` abstraction from the subagent discovery flow and replaces it with direct local return shapes:

- `discoverAgents()` now returns `{ agents } | { error }`.
- `resolveAgent()` now returns `AgentConfig | undefined`.
- `spawn_agent` keeps the same tool-boundary behavior by throwing the same registration and unknown-agent errors from `index.ts`.

### Why the current design is overcomplicated

`neverthrow` was only used inside `home/.pi/agent/extensions/subagents/agents.ts` for two local call sites. The abstraction did not provide a meaningful extension point because both consumers immediately matched the value at the boundary and converted the result into normal control flow.

For this repository, the extra `ok(...)` / `err(...)` constructors and `.match(...)` calls added a second result-handling vocabulary without changing behavior or improving isolation.

### Behavioral contract

The following behavior must remain unchanged:

- Subagent discovery still reads `~/.pi/agent/extensions/subagents/agents/*.md` through `getAgentDir()`.
- Unreadable agent directories still fail loud during extension registration.
- Empty or fully invalid agent directories still fail loud during extension registration.
- Per-file read or frontmatter parse failures are still skipped so one broken role does not hide the remaining usable roles.
- Agent entries are still sorted by name before being used in the tool schema and prompt guidance.
- Unknown `agent_type` values still throw from the pi tool boundary and include the requested name plus available agents.
- Depth limiting, subprocess execution, rendering, throttling, stderr handling, abort behavior, model lookup, tool schema construction, and returned child output are not changed.
- Public tool name, parameters, prompt guidance, and child process invocation are unchanged.

### Before and after

Before:

- `agents.ts` imported `ok`, `err`, and `Result` from `neverthrow`.
- `discoverAgents()` returned `Result<AgentConfig[], DiscoverError>`.
- `resolveAgent()` returned `Result<AgentConfig, { requested; available }>`.
- `index.ts` used `.match(...)` twice to unwrap those local results.

After:

- `agents.ts` no longer imports `neverthrow`.
- `discoverAgents()` returns a local discriminated union, `{ agents } | { error }`.
- `resolveAgent()` returns `AgentConfig | undefined`.
- `index.ts` uses normal `if` checks and throws the same error strings at the same boundary.

Evidence:

- Removed the third-party `Result` vocabulary from `home/.pi/agent/extensions/subagents/agents.ts`.
- Removed `.match(...)` control flow from `home/.pi/agent/extensions/subagents/index.ts`.
- Reduced the agent lookup path to a direct `find(...)` result instead of wrapping and immediately unwrapping it.
- Kept dependency files untouched because this PR is intentionally limited to behavior-preserving code simplification; removing `neverthrow` from `package.json`/`package-lock.json` can be done separately after local install validation.

### Validation

Commands run:

- Not run locally in this automation environment.

Static checks performed by inspection:

- Verified the only repository code references to `neverthrow` were in `home/.pi/agent/extensions/subagents/agents.ts`, `package.json`, and `package-lock.json`.
- Verified `discoverAgents()` still preserves all existing success and failure branches.
- Verified `resolveAgent()` still uses the same exact name comparison against the same sorted `agents` array.
- Verified `index.ts` still throws through the pi tool boundary for discovery failures and unknown `agent_type` values.

Expected validation for reviewer/local machine:

- `cd home/.pi/agent/extensions && npm run check`

### Risk assessment

Behavior-sensitive areas examined:

- Extension registration: still throws before tool registration when discovery fails.
- Unknown agent errors: still include the requested agent type and formatted available-agent list.
- Agent discovery ordering: unchanged `localeCompare` sort remains in place.
- Broken individual agent files: still skipped, not fatal.

The change is safe because it only removes a local result wrapper and leaves all IO, parsing, sorting, schema generation, execution, and rendering behavior unchanged.

### Scope

Intentionally not simplified:

- `package.json` / `package-lock.json` dependency removal for `neverthrow`, because lockfile changes should be generated and validated with `npm install` or equivalent local tooling.
- `zod` schemas, because they validate frontmatter and child process JSON at trust boundaries.
- Shell/profile configuration, because behavior preservation could not be proven safely without local shell validation.