### PR TITLE
bug: prevent compress from clobbering archive.tar

### DIFF
--- a/.local/bin/compress
+++ b/.local/bin/compress
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # Compress directory
 
+set -euo pipefail
+
 cLevel="3"
 PARAMS=()
 while (("$#")); do
   case "$1" in
   -cl | --compression-level)
+    if [[ $# -lt 2 ]]; then
+      echo "Error: missing compression level after '$1'" >&2
+      exit 1
+    fi
     if ! [[ $2 =~ ^[0-9]+$ ]]; then
       echo "Error: compression level must be an integer 0-19, got '$2'" >&2
       exit 1
@@ -32,5 +38,11 @@ while (("$#")); do
   esac
 done
 
-tar -cvf archive.tar "${PARAMS[@]}" &&
-  zstd -z --rm -"$cLevel" -T"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" archive.tar -o archive.tar.zst
+archive_tmp=$(mktemp "${TMPDIR:-/tmp}/compress.XXXXXX.tar")
+cleanup() {
+  rm -f "$archive_tmp"
+}
+trap cleanup EXIT
+
+tar -cvf "$archive_tmp" "${PARAMS[@]}" &&
+  zstd -z --rm -"$cLevel" -T"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" "$archive_tmp" -o archive.tar.zst

--- a/tests/compress-preserves-existing-archive.sh
+++ b/tests/compress-preserves-existing-archive.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin" "$tmp/input"
+printf 'sentinel\n' >"$tmp/archive.tar"
+printf 'payload\n' >"$tmp/input/file.txt"
+
+cat >"$tmp/bin/zstd" <<'ZSTD'
+#!/usr/bin/env bash
+set -euo pipefail
+
+remove=false
+input=
+output=
+
+while (($#)); do
+  case "$1" in
+    --rm)
+      remove=true
+      shift
+      ;;
+    -o)
+      output=$2
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      input=$1
+      shift
+      ;;
+  esac
+done
+
+if [[ -z $input || -z $output ]]; then
+  echo 'zstd stub missing input or output' >&2
+  exit 1
+fi
+
+cp "$input" "$output"
+if [[ $remove == true ]]; then
+  rm -f "$input"
+fi
+ZSTD
+chmod +x "$tmp/bin/zstd"
+
+(
+  cd "$tmp"
+  PATH="$tmp/bin:$PATH" "$repo_root/.local/bin/compress" input >/dev/null
+)
+
+actual=$(cat "$tmp/archive.tar")
+if [[ $actual != 'sentinel' ]]; then
+  echo 'compress modified an existing archive.tar in the working directory' >&2
+  exit 1
+fi
+
+[[ -s "$tmp/archive.tar.zst" ]]


### PR DESCRIPTION
### Bug

`.local/bin/compress` always creates `archive.tar` in the caller's current working directory as an intermediate file. If the user already has an `archive.tar` there, running `compress <input>` overwrites that file and then passes it to `zstd --rm`, which can remove it.

### Severity and impact

This is a data-loss bug. It affects normal use from any directory that already contains an `archive.tar` file, including a real archive the user intended to keep. The loss is irreversible unless the file is recoverable from backups.

### Evidence

Relevant implementation before this PR:

* `.local/bin/compress` used `tar -cvf archive.tar "${PARAMS[@]}"`.
* It then ran `zstd -z --rm ... archive.tar -o archive.tar.zst`.

That means the code path always writes the scratch tarball to a fixed user-visible filename in the working directory. If `archive.tar` already exists, `tar -cvf archive.tar ...` truncates/replaces it before compression. Because the next command uses `--rm`, the newly written file is removed after compression, leaving the original contents lost.

This is a real defect rather than a hypothetical edge case because `archive.tar` is a common archive filename and the script is explicitly a compression helper intended to be run from arbitrary directories.

### Reproduce

Setup:

```bash
tmp=$(mktemp -d)
cd "$tmp"
printf 'sentinel\n' > archive.tar
mkdir input
printf 'payload\n' > input/file.txt
```

Trigger:

```bash
/path/to/dotfiles/.local/bin/compress input
```

Actual result before this PR:

* `archive.tar` is overwritten by the script's temporary tar stream and then removed by `zstd --rm`.
* The original `sentinel` contents are lost.

Expected result:

* `archive.tar` should remain unchanged.
* The script's temporary tarball should not collide with user files in the working directory.

### Root cause

The script used a fixed intermediate filename, `archive.tar`, in the caller's current working directory. That made internal scratch state share a namespace with user-owned files.

### Fix

Use `mktemp` to create the intermediate tarball under `${TMPDIR:-/tmp}`, install an `EXIT` cleanup trap, and pass that private temporary path to both `tar` and `zstd`. The final output name remains `archive.tar.zst`, preserving the script's existing user-facing behavior.

I also added a missing-argument guard for `--compression-level` because `set -u` makes an omitted value fail through an unhelpful unbound-variable error.

### Validation

Added regression test:

```bash
tests/compress-preserves-existing-archive.sh
```

The test creates a working directory containing a sentinel `archive.tar`, stubs `zstd` to avoid depending on the host zstd binary, runs `.local/bin/compress input`, and fails unless the sentinel file remains unchanged.

Commands intended for reviewer/local validation:

```bash
bash tests/compress-preserves-existing-archive.sh
```

GitHub Actions shellcheck will also run for this PR.

### Scope

Intentionally not changed:

* The final output filename remains `archive.tar.zst`.
* Compression defaults and accepted flags are unchanged.
* No archive naming scheme or CLI redesign was introduced.