### PR TITLE
refactor: simplify bridge client storage

### DIFF
--- a/pi-web/src/bridge.ts
+++ b/pi-web/src/bridge.ts
@@ -66,7 +66,7 @@ export class Bridge {
   private readonly runtime: BridgeRuntime;
   private readonly onClientCountChange: ((count: number) => void) | undefined;
   private unsubscribe: (() => void) | null = null;
-  private clients = new Map<ClientSender, true>();
+  private clients = new Set<ClientSender>();
   private disposed = false;
 
   constructor(opts: BridgeOptions) {
@@ -94,7 +94,7 @@ export class Bridge {
 
   private broadcastEvent(event: unknown): void {
     const payload = JSON.stringify(event);
-    for (const send of this.clients.keys()) {
+    for (const send of this.clients) {
       try {
         send(payload);
       } catch {
@@ -112,7 +112,7 @@ export class Bridge {
   }
 
   addClient(send: ClientSender): RemoveClient {
-    this.clients.set(send, true);
+    this.clients.add(send);
     if (this.onClientCountChange !== undefined) {
       this.onClientCountChange(this.clients.size);
     }


### PR DESCRIPTION
### Simplification

Replace `Bridge`'s connected-client storage from `Map<ClientSender, true>` to `Set<ClientSender>` in `pi-web/src/bridge.ts`.

### Why the current design is overcomplicated

The bridge only needs to track whether a client sender is present. The `true` value in `Map<ClientSender, true>` is never read as state and does not represent any separate ownership, metadata, lifecycle, or extension point.

A `Set<ClientSender>` directly models the existing responsibility: maintain a unique collection of connected send closures that can be iterated, removed, cleared, and counted.

### Behavioral contract

Behavior that must remain unchanged:

- Adding a client registers a unique sender for broadcast fan-out.
- Removing a client stops later broadcasts to that sender.
- Per-client send errors remain best-effort and do not stop broadcasts to other clients.
- `onClientCountChange` is called after add, after successful remove, and with `0` on dispose.
- `clientCount` still reports the number of registered senders.
- `dispose()` still unsubscribes, clears all clients, is idempotent, and reports zero clients.
- Session command handling, runtime rebinding, response formatting, protocol parsing, model handling, and session state behavior are unchanged.

### Before and after

Before:

- `Bridge` stored clients in `Map<ClientSender, true>`.
- `addClient()` used `this.clients.set(send, true)`.
- Broadcast iterated `this.clients.keys()`.
- Removal, clearing, and counting used Map APIs even though the stored value was unused.

After:

- `Bridge` stores clients in `Set<ClientSender>`.
- `addClient()` uses `this.clients.add(send)`.
- Broadcast iterates `this.clients` directly.
- Removal, clearing, and counting keep the same semantics with the smaller collection type.

Specific evidence:

- Removed the redundant `true` value from the client collection.
- Reduced the client storage API surface from key/value map semantics to membership-only set semantics.
- Kept all external bridge APIs, protocol responses, and runtime interfaces unchanged.
- No public API, persisted data, wire format, configuration, logging, or metrics changed.

### Validation

Commands intended for this change:

- `cd pi-web && npm run build`
- `cd pi-web && npm run typecheck`
- `cd pi-web && npm test`

I could not run local commands in this automation environment because repository cloning/execution was unavailable. Static validation performed instead:

- Inspected `pi-web/src/bridge.ts` and confirmed every client collection operation maps directly from `Map` to equivalent `Set` semantics:
  - `set(send, true)` -> `add(send)`
  - `keys()` iteration -> direct Set iteration
  - `delete(send)` unchanged boolean success behavior
  - `clear()` unchanged
  - `size` unchanged
- Inspected `pi-web/tests/bridge.test.ts` and confirmed existing tests cover construction subscription, broadcast fan-out, remove-client behavior, best-effort send errors, dispose behavior, command dispatch, session rebinding, and cancellation paths.

### Risk assessment

Behavior-sensitive areas examined:

- Duplicate sender handling: both `Map` and `Set` preserve unique membership by function identity.
- Iteration order: both `Map` keys and `Set` entries iterate in insertion order.
- Removal return value: both `Map.prototype.delete` and `Set.prototype.delete` return whether an entry existed.
- Client counts: both expose equivalent `.size` semantics.
- Disposal: both clear all entries with `.clear()`.

The change is safe because the previous Map value carried no information and no caller could observe it.

### Scope

Intentionally not simplified:

- Command dispatch structure in `Bridge`, because that is behavior-dense and already covered by protocol-specific tests.
- Runtime/session interfaces, because those define the bridge boundary and changing them would expand review scope.
- `subagents` code, because existing open simplification PRs already touch that area.
- Shell/profile dotfiles, because behavior preservation is harder to prove without local environment validation.