### PR TITLE
bug: prevent dumpcert documented usage from omitting port

### DIFF
--- a/.local/bin/dumpcert
+++ b/.local/bin/dumpcert
@@ -3,10 +3,16 @@
 set -eo pipefail
 
 [[ -z $domain ]] && echo "Usage: domain=example.com [sni=example.com] dumpcert" && exit 1
+
+case "$domain" in
+  *:*) connect=$domain ;;
+  *) connect=$domain:443 ;;
+esac
+
 if [[ -z $sni ]]; then
   set -x
-  echo | openssl s_client -showcerts -noservername -connect "$domain" 2>/dev/null | openssl x509 -inform pem -noout -text
+  echo | openssl s_client -showcerts -noservername -connect "$connect" 2>/dev/null | openssl x509 -inform pem -noout -text
 else
   set -x
-  echo | openssl s_client -showcerts -servername "$sni" -connect "$domain" 2>/dev/null | openssl x509 -inform pem -noout -text
+  echo | openssl s_client -showcerts -servername "$sni" -connect "$connect" 2>/dev/null | openssl x509 -inform pem -noout -text
 fi

--- a/tests/dumpcert-default-port.sh
+++ b/tests/dumpcert-default-port.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/openssl" <<'OPENSSL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} == s_client ]]; then
+  printf '%s\n' "$*" >"$OPENSSL_ARGS_FILE"
+  printf '%s\n' '-----BEGIN CERTIFICATE-----' 'stub' '-----END CERTIFICATE-----'
+  exit 0
+fi
+
+if [[ ${1:-} == x509 ]]; then
+  cat >/dev/null
+  printf 'decoded certificate\n'
+  exit 0
+fi
+
+echo "unexpected openssl invocation: $*" >&2
+exit 1
+OPENSSL
+chmod +x "$tmp/openssl"
+
+OPENSSL_ARGS_FILE="$tmp/openssl.args" PATH="$tmp:$PATH" domain=example.com "$repo_root/.local/bin/dumpcert" >/dev/null
+
+args=$(cat "$tmp/openssl.args")
+case "$args" in
+  *'-connect example.com:443'*) ;;
+  *)
+    echo "dumpcert did not add the default HTTPS port: $args" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
### Bug

`.local/bin/dumpcert` documents usage as `domain=example.com [sni=example.com] dumpcert`, but passes `$domain` directly to `openssl s_client -connect`. `openssl s_client -connect` expects a host:port endpoint, so the documented `domain=example.com` invocation does not provide a valid connection target.

### Severity and impact

This breaks the normal user flow for the helper: following the script's own usage message fails unless the user already knows to include `:443`, despite the usage text not saying that. The impact is limited to this certificate inspection helper, but it makes the documented default invocation incorrect.

### Evidence

Relevant implementation before this PR:

* `.local/bin/dumpcert` line 7 printed `Usage: domain=example.com [sni=example.com] dumpcert`.
* Lines 10 and 13 passed `-connect "$domain"` directly to `openssl s_client`.

The script therefore advertises a bare hostname but sends that bare hostname to an option that requires an endpoint. This is a direct contradiction between documented usage and implementation.

### Reproduce

Setup:

```bash
cd /path/to/dotfiles
```

Trigger using the script's own usage form:

```bash
domain=example.com .local/bin/dumpcert
```

Actual result before this PR:

* `openssl s_client` receives `-connect example.com`.
* The command does not include the required HTTPS port.

Expected result:

* `domain=example.com` should connect to `example.com:443` by default.
* Explicit endpoints such as `domain=example.com:8443` should remain supported.

### Root cause

The script conflated the user-facing `domain` input with the OpenSSL `-connect` endpoint. It did not derive a host:port value when the caller supplied a bare hostname, even though that is the documented invocation.

### Fix

Build a `connect` variable before invoking OpenSSL. If `domain` already contains a colon, preserve it as an explicit endpoint. Otherwise append `:443`. Both the SNI and no-SNI paths now pass `-connect "$connect"`.

### Validation

Added regression test:

```bash
tests/dumpcert-default-port.sh
```

The test stubs `openssl`, runs the documented invocation with `domain=example.com`, captures the `s_client` arguments, and fails unless `-connect example.com:443` is used.

Commands intended for reviewer/local validation:

```bash
bash tests/dumpcert-default-port.sh
```

GitHub Actions shellcheck will also run for this PR.

### Scope

Intentionally not changed:

* The environment-variable based interface is preserved.
* Explicit `domain=host:port` endpoints are still passed through.
* SNI behavior is unchanged apart from using the corrected connection endpoint.