### PR TITLE
refactor: simplify toast reducer flow

### DIFF
--- a/pi-web/src/web/state.ts
+++ b/pi-web/src/web/state.ts
@@ -97,11 +97,7 @@ export function reducer(state: AppState, action: Action): AppState {
     case "set_stick_to_bottom":
       return { ...state, stickToBottom: action.value };
     case "show_toast":
-      toastSeq += 1;
-      return {
-        ...state,
-        toast: { id: toastSeq, text: action.text, kind: action.kind },
-      };
+      return toast(state, action.text, action.kind);
     case "dismiss_toast":
       return state.toast && state.toast.id === action.id
         ? { ...state, toast: null }

--- a/pi-web/tests/state.test.ts
+++ b/pi-web/tests/state.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { initialState, reducer } from "../src/web/state.ts";
+
+test("reducer: show_toast creates a dismissible toast", () => {
+  const shown = reducer(initialState, {
+    type: "show_toast",
+    text: "Not connected",
+    kind: "info",
+  });
+
+  assert.equal(shown.toast?.text, "Not connected");
+  assert.equal(shown.toast?.kind, "info");
+  assert.equal(typeof shown.toast?.id, "number");
+
+  const dismissed = reducer(shown, {
+    type: "dismiss_toast",
+    id: shown.toast!.id,
+  });
+  assert.equal(dismissed.toast, null);
+});
+
+test("reducer: failed responses use the same toast path", () => {
+  const failed = reducer(initialState, {
+    type: "response",
+    msg: { type: "response", id: "req-1", ok: false, error: "agent busy" },
+  });
+
+  assert.equal(failed.toast?.text, "agent busy");
+  assert.equal(failed.toast?.kind, "error");
+  assert.equal(typeof failed.toast?.id, "number");
+});


### PR DESCRIPTION
### Simplification

Consolidate frontend toast creation in `pi-web/src/web/state.ts` so both explicit `show_toast` actions and failed server responses use the same `toast()` helper.

### Why the current design is overcomplicated

The reducer had two implementations of the same responsibility:

- `show_toast` incremented `toastSeq` inline and constructed the `Toast` object directly.
- failed responses used the `toast()` helper, which also incremented `toastSeq` and constructed the same `Toast` shape.

That duplicate state-update path made toast sequencing and object construction slightly harder to audit than necessary. There is no behavior distinction between the two paths that justifies maintaining two implementations.

### Behavioral contract

Behavior that must remain unchanged:

- `show_toast` creates a toast with a fresh numeric id, the requested text, and the requested kind.
- failed server responses create an error toast with the response error text.
- toast ids continue to be monotonically generated by the module-level `toastSeq` counter.
- `dismiss_toast` still clears only the currently visible toast when the id matches.
- All other reducer actions, message coercion, session/model state coercion, event handling, and exported types remain unchanged.
- No protocol shape, persisted data, configuration, public API, logging, or metrics changed.

### Before and after

Before:

- `show_toast` duplicated the helper's logic by incrementing `toastSeq` and constructing `{ id, text, kind }` inline.
- failed responses used `toast(state, msg.error, "error")`.

After:

- `show_toast` calls `toast(state, action.text, action.kind)`.
- failed responses continue to use the same helper.
- A focused reducer test covers both the explicit toast path and the failed-response path.

Specific evidence:

- Removed one duplicate toast construction path from `pi-web/src/web/state.ts`.
- Added `pi-web/tests/state.test.ts` to pin the shared toast behavior.
- Kept the reducer action type, state shape, helper behavior, and consumer-facing UI state unchanged.

### Validation

Commands intended for this change:

- `cd pi-web && npm run build`
- `cd pi-web && npm run typecheck`
- `cd pi-web && npm test`

I could not run local commands in this automation environment because repository cloning/execution was unavailable. Static validation performed instead:

- Inspected `pi-web/src/web/state.ts` and confirmed `show_toast` now delegates to the existing `toast()` helper without changing action inputs or resulting state shape.
- Added `pi-web/tests/state.test.ts` covering explicit toast creation, matching-id dismissal, and failed-response toast creation.
- Confirmed `pi-web/package.json` runs `node --test 'tests/*.test.ts'`, so the new test file is included by the existing test command.

### Risk assessment

Behavior-sensitive areas examined:

- Toast id generation: still uses the same module-level `toastSeq` increment in the same helper already used by failed responses.
- Toast payload shape: still `{ id, text, kind }`.
- Dismiss behavior: unchanged and now covered by the new test.
- Other reducer cases: left untouched.

The change is safe because it removes duplicated implementation while preserving the single existing helper's behavior.

### Scope

Intentionally not simplified:

- The broader reducer structure, because command/event handling is behavior-dense and should remain easy to review.
- Message/session/model coercion helpers, because they sit on a wire-format trust boundary.
- WebSocket reconnect logic, because changing that would affect timing-sensitive behavior.
- `subagents` code, because existing open simplification PRs already touch that area.