### PR TITLE
refactor: simplify browser opener command selection

### DIFF
--- a/pi-web/src/open-browser.ts
+++ b/pi-web/src/open-browser.ts
@@ -14,39 +14,35 @@ export type SpawnFn = (
   options: SpawnOptions,
 ) => { unref(): void };
 
+type BrowserCommand = (url: string) => { cmd: string; args: string[] };
+
+const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, BrowserCommand>> = {
+  darwin: (url) => ({ cmd: "open", args: [url] }),
+  linux: (url) => ({ cmd: "xdg-open", args: [url] }),
+  win32: (url) => ({ cmd: "cmd", args: ["/c", "start", "", url] }),
+};
+
 export function openBrowser(
   url: string,
   spawn: SpawnFn = defaultSpawn as unknown as SpawnFn,
 ): void {
-  const platform = process.platform;
-  let cmd: string;
-  let args: string[];
-
-  if (platform === "darwin") {
-    cmd = "open";
-    args = [url];
-  } else if (platform === "linux") {
-    cmd = "xdg-open";
-    args = [url];
-  } else if (platform === "win32") {
-    cmd = "cmd";
-    args = ["/c", "start", "", url];
-  } else {
+  const command = BROWSER_COMMANDS[process.platform]?.(url);
+  if (!command) {
     console.warn(
-      `[pi-web] Cannot auto-open browser on platform "${platform}". Open ${url} manually.`,
+      `[pi-web] Cannot auto-open browser on platform "${process.platform}". Open ${url} manually.`,
     );
     return;
   }
 
   try {
-    const child = spawn(cmd, args, {
+    const child = spawn(command.cmd, command.args, {
       detached: true,
       stdio: "ignore",
     });
     child.unref();
   } catch (err) {
     console.warn(
-      `[pi-web] Failed to spawn ${cmd}: ${(err as Error).message}. Open ${url} manually.`,
+      `[pi-web] Failed to spawn ${command.cmd}: ${(err as Error).message}. Open ${url} manually.`,
     );
   }
 }

--- a/pi-web/tests/open-browser.test.ts
+++ b/pi-web/tests/open-browser.test.ts
@@ -38,6 +38,20 @@ test("openBrowser: spawns 'xdg-open' on linux", () => {
     const { fn, calls } = makeFakeSpawn();
     openBrowser("http://127.0.0.1:7878/", fn);
     assert.equal(calls[0]!.cmd, "xdg-open");
+    assert.deepEqual([...calls[0]!.args], ["http://127.0.0.1:7878/"]);
+  } finally {
+    Object.defineProperty(process, "platform", { value: original });
+  }
+});
+
+test("openBrowser: spawns 'cmd /c start' on win32", () => {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", { value: "win32" });
+  try {
+    const { fn, calls } = makeFakeSpawn();
+    openBrowser("http://127.0.0.1:7878/", fn);
+    assert.equal(calls[0]!.cmd, "cmd");
+    assert.deepEqual([...calls[0]!.args], ["/c", "start", "", "http://127.0.0.1:7878/"]);
   } finally {
     Object.defineProperty(process, "platform", { value: original });
   }


### PR DESCRIPTION
### Simplification

Replace the `openBrowser` platform-selection `if`/`else if` chain with a small `BROWSER_COMMANDS` command table. The behavior still maps each supported platform to the same command and arguments, then runs the same detached/ignored child process.

### Why the current design is overcomplicated

The previous implementation encoded a static platform-to-command mapping as branching control flow. That made adding or auditing supported platforms require reading through command-selection logic mixed with warning and spawn handling. The branch chain did not provide a real extension point or behavior beyond returning one command tuple per supported platform.

### Behavioral contract

The following behavior must remain unchanged:

- `darwin` spawns `open <url>`.
- `linux` spawns `xdg-open <url>`.
- `win32` spawns `cmd /c start "" <url>`.
- Supported platforms spawn with `{ detached: true, stdio: "ignore" }` and call `unref()`.
- Unsupported platforms do not spawn and warn that the URL must be opened manually.
- Spawn failures still warn with the failed command and manual-open fallback.
- The public `openBrowser(url, spawn?)` helper signature is unchanged.
- No server routing, WebSocket, runtime, persistence, or user-visible CLI behavior changes.

### Before and after

Before, `openBrowser` selected `cmd` and `args` through a mutable pair of local variables populated by an `if`/`else if` chain, with fallback warning behavior in the final `else`.

After, supported platforms are represented by `BROWSER_COMMANDS`, a small map from platform to command builder. `openBrowser` now retrieves one command object and keeps the unsupported-platform warning and spawn/error handling in one direct path.

Evidence:

- Platform command selection moved from branching control flow to `BROWSER_COMMANDS` in `pi-web/src/open-browser.ts`.
- The mutable `cmd`/`args` setup path was removed.
- The public function surface remains the same.
- Test coverage now explicitly includes the Windows command mapping in addition to the existing macOS, Linux, and unsupported-platform cases.

### Validation

Static validation performed by inspection in this tool-limited run:

- Confirmed existing open simplification PRs are in unrelated areas: #74 subagent discovery, #76 bridge client storage, #78 toast reducer flow.
- Reviewed `pi-web/src/open-browser.ts` and `pi-web/tests/open-browser.test.ts` before editing.
- Preserved the existing tests for macOS, Linux, spawn options, and unsupported platforms.
- Added a Windows mapping assertion for `cmd /c start "" <url>`.

Commands not run: local `npm test`, `npm run typecheck`, and `npm run build` were unavailable in this automation environment because repository checkout/local command execution was not available through the GitHub connector. The change is intentionally limited to pure command-selection refactoring plus tests that document the unchanged command contract.

### Risk assessment

Behavior-sensitive areas examined:

- Platform string mapping: the same `process.platform` values are supported.
- Spawn arguments: preserved for macOS, Linux, and Windows; Windows is now explicitly tested.
- Fallback path: unsupported platforms still warn and return without spawning.
- Error path: spawn exceptions still warn with the attempted command and URL fallback.

The change is safe because it does not alter the side-effect boundary or add new behavior; it only changes how the same command tuple is selected before spawning.

### Scope

Intentionally not simplified:

- No changes to server startup or `PI_WEB` auto-open behavior.
- No changes to WebSocket, bridge, runtime, session, or UI code.
- No dependency, package, or lockfile changes.
- No broader test helper extraction, because that would be a separate test-only cleanup and not needed to prove this behavior-preserving refactor.