### PR TITLE
refactor: simplify state exports

### DIFF
--- a/pi-web/src/web/state.ts
+++ b/pi-web/src/web/state.ts
@@ -1,8 +1,4 @@
-import {
-  THINKING_LEVELS,
-  isThinkingLevel,
-  isServerEventType,
-} from "../shared/wire.ts";
+import { isThinkingLevel } from "../shared/wire.ts";
 import type {
   ModelRef,
   ServerEvent,
@@ -239,5 +235,3 @@ function coerceMessage(raw: unknown): ChatMessage | null {
 function coerceMessages(list: unknown[]): ChatMessage[] {
   return list.map(coerceMessage).filter((m): m is ChatMessage => m !== null);
 }
-
-export { THINKING_LEVELS, isServerEventType };


### PR DESCRIPTION
### Simplification

Remove the redundant `pi-web/src/web/state.ts` re-export of protocol-level helpers from `shared/wire.ts`.

`state.ts` now imports only the protocol guard it actually uses for reducer coercion, `isThinkingLevel`, and no longer exposes `THINKING_LEVELS` or `isServerEventType` as an alternate route to the wire/protocol API.

### Why the current design is overcomplicated

`state.ts` owns frontend reducer state, coercion, and reducer actions. It was also acting as a pass-through export for unrelated wire-level symbols:

- `THINKING_LEVELS`
- `isServerEventType`

That extra export path did not provide a real abstraction boundary. Current consumers already import these symbols from `shared/wire.ts` directly, and `state.ts` does not use either of the re-exported values except as pass-through imports. Keeping the pass-through made the reducer module appear to own more of the protocol surface than it actually does.

### Behavioral contract

The following behavior must remain unchanged:

- Reducer action handling is unchanged.
- Response coercion is unchanged.
- Invalid or missing thinking levels still fall back to `"medium"` via `isThinkingLevel`.
- Session, model, message, toast, streaming, connection, and sticky-scroll state behavior are unchanged.
- Existing UI imports of `THINKING_LEVELS` continue to come from `shared/wire.ts`.
- Server-event validation behavior is unchanged and remains owned by `shared/wire.ts` / `protocol.ts`.
- No wire format, persisted data, command contract, response shape, logging, metrics, or user-visible behavior changes.

### Before and after

Before:

- `state.ts` imported `THINKING_LEVELS`, `isThinkingLevel`, and `isServerEventType` from `shared/wire.ts`.
- `state.ts` used only `isThinkingLevel` internally.
- `state.ts` re-exported `THINKING_LEVELS` and `isServerEventType`, creating an unused alternate protocol import path from a reducer module.

After:

- `state.ts` imports only `isThinkingLevel` from `shared/wire.ts`.
- The unused pass-through export is removed.
- Protocol constants and guards remain available from their owning module, `shared/wire.ts`.

Specific evidence:

- Removed two unused value imports from `pi-web/src/web/state.ts`.
- Removed the trailing pass-through export from `pi-web/src/web/state.ts`.
- Reduced the reducer module's API surface to state/reducer concepts only.
- Confirmed existing `THINKING_LEVELS` consumer imports directly from `../../shared/wire.ts`.
- Confirmed existing server-event guard users import from `shared/wire.ts` or `protocol.ts`, not through `state.ts`.

### Validation

Static validation performed through repository inspection:

- `GitHub.search` for `THINKING_LEVELS` found only `shared/wire.ts`, `state.ts`, and `thinking-picker.tsx`; `thinking-picker.tsx` already imports directly from `../../shared/wire.ts`.
- `GitHub.search` for `isServerEventType` found only `shared/wire.ts`, `protocol.ts`, `state.ts`, and `bridge.ts`; no caller imports it from `state.ts`.
- Inspected `pi-web/src/web/state.ts` and confirmed reducer logic is unchanged except for the removed pass-through import/export.

Commands not run in this connector environment:

- `cd pi-web && npm run build && npm run typecheck && npm test`

This PR is intentionally narrow because local command execution was unavailable here.

### Risk assessment

Risk is low because this removes an unused internal pass-through export without changing reducer implementation, protocol definitions, UI component imports, or message handling. The only module edited is `state.ts`, and the reducer body is unchanged.

Behavior-sensitive areas examined:

- thinking-level fallback behavior,
- existing imports of `THINKING_LEVELS`,
- existing imports of `isServerEventType`,
- frontend reducer action handling,
- server-event guard ownership.

### Scope

Intentionally not simplified:

- The existing direct imports from `shared/wire.ts` in UI components, because those are already the clearer ownership boundary.
- `isThinkingLevel`, because `state.ts` uses it to preserve response coercion behavior.
- Broader protocol/state module reshaping, because that would be a larger API-boundary change.
- Existing open simplification PRs (#74 and #82), to avoid overlapping work.